### PR TITLE
Added --provider virtual box to vagrant up.

### DIFF
--- a/init_project.sh
+++ b/init_project.sh
@@ -196,7 +196,7 @@ fi
 status "Initializing vagrant box"
 cd "${vagrant_dir}"
 
-vagrant up 2> >(logError) | {
+vagrant up --provider virtualbox 2> >(logError) | {
   while IFS= read -r line
   do
     filterVagrantOutput "${line}"


### PR DESCRIPTION
So when I ran 

```
bash init_project.sh
```

I got:

```
[2016-11-14 09:08:57] Initializing vagrant box [init_project.sh]
["vmware_desktop", "vmware_fusion", "vmware_workstation"] [Unknown source file]
[2016-11-14 09:09:03] Directory 'vagrant-magento/etc' was not mounted as expected by Vagrant.
        Please make sure that Vagrant is able to mount VirtualBox shared folders on your environment (see https://www.vagrantup.com/docs/synced-folders/basic_usage.html ) [/Users/johnwineman/vagrant/vagrant-magento/scripts/host/check_mounted_directories.sh]
```
running `vagrant up` manually:

```
➜  vagrant-magento git:(2.0) ✗ vagrant up
Bringing machine 'default' up with 'vmware_fusion' provider...
==> default: Box 'base' could not be found. Attempting to find and install...
    default: Box Provider: vmware_desktop, vmware_fusion, vmware_workstation
    default: Box Version: >= 0
==> default: Box file was not detected as metadata. Adding it directly...
==> default: Adding box 'base' (v0) for provider: vmware_desktop, vmware_fusion, vmware_workstation
    default: Downloading: base
An error occurred while downloading the remote file. The error
message, if any, is reproduced below. Please fix this error and try
again.

Couldn't open file vagrant-magento/base
```

After some debugging I found that [Vagrant defaults to VMWare if the VMWare plugin is installed](https://github.com/mitchellh/vagrant/issues/4654).  My company uses VMWare for our other VMs which is why I was seeing this issue.

```
vagrant up --provider virtualbox 
```

Fixed my issue so I figured it was worth a PR adding it to init_project.sh since you explicitly require VirutalBox.