### PR TITLE
Adds deep_merge Ruby implementation

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,7 @@
 Vagrant.require_version ">= 1.8"
 
 require 'yaml'
+require './deep_merge'
 
 module OS
     def OS.is_windows

--- a/deep_merge.rb
+++ b/deep_merge.rb
@@ -1,0 +1,23 @@
+class Hash
+  def deep_merge(other_hash, &block)
+    dup.deep_merge!(other_hash, &block)
+  end
+
+  def deep_merge!(other_hash, &block)
+    other_hash.each_pair do |current_key, other_value|
+      this_value = self[current_key]
+
+      self[current_key] = if this_value.is_a?(Hash) && other_value.is_a?(Hash)
+        this_value.deep_merge(other_value, &block)
+      else
+        if block_given? && key?(current_key)
+          block.call(current_key, this_value, other_value)
+        else
+          other_value
+        end
+      end
+    end
+
+    self
+  end
+end


### PR DESCRIPTION
Solves https://github.com/paliarush/magento2-vagrant-for-developers/issues/124

Adds an implementation for the `deep_merge` method that comes from Ruby on Rails usually.